### PR TITLE
Remove references to Bugsnag gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ gem 'sqlite3'
 gem 'pg'
 gem 'database_cleaner', '1.0.1'
 
-gem "bugsnag"
-
 group :test do
  gem 'simplecov-rcov'
  gem 'yarjuf'

--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -49,13 +49,13 @@ module Spree
           if Rails.env.development?
             Rails.logger.info("[Error][PayPal] #{message}")
           else
-            Bugsnag.notify(RuntimeError.new(message))
+            ErrorReporting.report RuntimeError.new(message)
           end
           flash[:error] = Spree.t(:unprocessable_order)
           redirect_to error_path
         end
       rescue SocketError => e
-        Bugsnag.notify(e)
+        ErrorReporting.report e
         flash[:error] = Spree.t('flash.connection_failed', :scope => 'paypal')
         redirect_to error_path
       end


### PR DESCRIPTION
This PR removes references to the `bugsnag` gem, in favor of using GCloud reporting (through the `ErrorReporting` module defined in Store).

[Asana](https://app.asana.com/0/913172824929361/1118657062114618)