### PR TITLE
complete without redirects

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -84,7 +84,18 @@ module Spree
         end
       end
 
-      redirect_to_order(order.state)
+      checkout_controller = Spree::CheckoutController.new.tap do |controller|
+        controller.env = env
+        controller.request = request
+        controller.response = response
+      end
+
+      checkout_controller.process(:complete)
+
+      # This is similar to what `redirect_to` does
+      self.status = checkout_controller.status
+      self.location = checkout_controller.location
+      self.response_body = checkout_controller.response_body
     end
 
     def cancel


### PR DESCRIPTION
I've managed to reproduce the issue. You need to close your tab quickly after the payment is processed but before the redirect is processed by the browser. 

To fix this problem, let's make sure the complete code is executed on the same request. After thinking for a while on how to extract the code to other module/method and use on both actions, I got no good way to do it (that is, any maintenance would have to change both the gem and the code, and we risk to forget the gem), so instead I'm opting for explicitly executing the spree code on the gem.

[asana](https://app.asana.com/0/459695523021135/1201445262655664)