### PR TITLE
paypal executing to wrong action

### DIFF
--- a/app/controllers/spree/paypal_controller.rb
+++ b/app/controllers/spree/paypal_controller.rb
@@ -90,7 +90,7 @@ module Spree
         controller.response = response
       end
 
-      checkout_controller.process(:complete)
+      checkout_controller.process(order.state)
 
       # This is similar to what `redirect_to` does
       self.status = checkout_controller.status


### PR DESCRIPTION
Fixes #7, where it not always execute complete, but rather execute the order state.

Doesn't seems to be an issue, though. In fact, it avoid some errors for nonexistent actions. Not sure if we want to merge this.